### PR TITLE
Fix for class-scanning in 5.55+ during install

### DIFF
--- a/drush/install.provision.inc
+++ b/drush/install.provision.inc
@@ -97,7 +97,7 @@ function _provision_civicrm_install_civicrm($dbuser, $dbpass, $dbhost, $dbname, 
   }
 
   // NB: civicrm drush functions expect the parent dir of the civicrm code base.
-  $modPath = $crmPath . '/../';
+  $modPath = dirname($crmPath) . '/';
 
   // Setup all required files/civicrm/* directories
   if (!_civicrm_create_files_dirs($civicrmInstallerHelper, $modPath)) {


### PR DESCRIPTION
Before
-------
$civicrm_root ends up looking like `/var/aegir/something/civicrm/..//civicrm`, which prevents class-scanning from finding any files that are in subfolders under civicrm, which is pretty much all of them. The error gets hidden somewhere but if you debug you'll see that it crashes during the cache clear at https://github.com/civicrm/civicrm-drupal/blob/1d0bbd844f20b6ab9abc62f3011d8ac7f92b5d02/civicrm.module#L1245, with an error about not finding the `spec_gatherer` service.

Note $civicrm_root ends up getting written out properly later so it's only during this initial phase that it's a problem.

After
------
$civicrm_root ends up looking like `/var/aegir/something/civicrm` and class-scanning can find files.

Comments
------------
You can easily see the issue by running the following on a functioning install:

`cv ev '$p = "/path/to/civicrm/..//civicrm"; print_r(CRM_Utils_File::findFiles($p, "*.php"));'`

vs

`cv ev '$p = "/path/to/civicrm"; print_r(CRM_Utils_File::findFiles($p, "*.php"));'`

The first only gives about 4 files. The second gives thousands.